### PR TITLE
Fix properties names' casing problem

### DIFF
--- a/src/MagicModules/TemplateMagicModulesInput.ts
+++ b/src/MagicModules/TemplateMagicModulesInput.ts
@@ -258,7 +258,7 @@ function appendUxOptions(output: string[], options: ModuleOption[], prefix: stri
         }
 
         output.push(prefix + "- " + dataType);
-        output.push(prefix + "  name: '" + ToCamelCase(option.NameAnsible) + "'");
+        output.push(prefix + "  name: '" + option.NameGoSdk + "'");
         output.push(prefix + "  description: '" + EscapeDocumentation(option.Documentation) + "'");
 
         if (!appendReadOnly)


### PR DESCRIPTION
This pr is aimed to fix some casing problem in the name of properties.
The original `toCamalCase(option.NameAnsible)` cannot properly handle words with those capitalized abbreviations. For example, the swagger name `automaticOSUpgradePolicy` will be transformed as `automaticOsupgradePolicy`.
Since the `NameGoSDK` is the result of proper handled of those abbreviations (as well as removed all illegal characters), I just use this value to replace the original name.