### PR TITLE
Enable source map by default

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "types": [
             "node"
         ],
-        "target": "es2016"
+        "target": "es2016",
+        "sourceMap": true
     },
     "include": [
         "src"


### PR DESCRIPTION
This pr enables source-map functionality by default.
Using source map, you can put breaking points to typescript files in order to debug.