### PR TITLE
Explicit ignore some useless path

### DIFF
--- a/src/Common/CodeModel.ts
+++ b/src/Common/CodeModel.ts
@@ -226,7 +226,7 @@ export class CodeModel
 
     public HasDelete(): boolean
     {
-        return this.GetMethod("Delete") != null;
+        return this.GetMethod("Delete") != null || this.GetMethod("Remove") != null;
     }
 
     public GetMethodOptionNames(methodName: string): string[]


### PR DESCRIPTION
A ignore list is added in this pr, to explicitly skip some problematic paths, including:
* '/name': usually there is a 'name' parameter in the `path` of rest api call. The '/name' path conflicts with that in-path name parameter every time we run magic-modules
* '/provisioningState': this field is used by SDK to track the long-running-operation or something, user on client side is not interested in this.
* '/type': this field is used for returning the type of this resource, this is useless for use on client side.